### PR TITLE
Rails 3.0 Refactoring

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,7 @@ GEM
     builder (2.1.2)
     i18n (0.5.0)
     rake (0.9.2)
+    sqlite3 (1.3.3)
     tzinfo (0.3.25)
 
 PLATFORMS
@@ -29,3 +30,4 @@ PLATFORMS
 DEPENDENCIES
   isbn_validation!
   rake
+  sqlite3

--- a/lib/isbn_validation.rb
+++ b/lib/isbn_validation.rb
@@ -23,75 +23,84 @@ require "isbn_validation/version"
 # * <tt>:unless</tt> - Specifies a method, proc or string to call to determine if the validation should
 #   not occur (e.g. <tt>:unless => :skip_validation</tt>, or <tt>:unless => Proc.new { |user| user.signup_step <= 2 }</tt>).  The
 #   method, proc or string should return or evaluate to a true or false value.
-module Zerosum
-  module ValidationExtensions
-    module IsbnValidation
-      ISBN10_REGEX = /^(?:\d[\ |-]?){9}[\d|X]$/
-      ISBN13_REGEX = /^(?:\d[\ |-]?){13}$/
+module ValidationExtensions
+  module IsbnValidation
+    ISBN10_REGEX = /^(?:\d[\ |-]?){9}[\d|X]$/
+    ISBN13_REGEX = /^(?:\d[\ |-]?){13}$/
 
-      def self.included(base)
-        base.extend(ClassMethods)
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    class IsbnFormatValidator < ActiveModel::EachValidator
+      def initialize(options)
+        options[:message]   ||= "is not a valid ISBN code"
+        options[:allow_nil] ||= false
+        super(options)
       end
 
-      module ClassMethods
-        def validates_isbn(*attr_names)
-          configuration = { 
-            :message => "is not a valid ISBN code"
-          }
+      def validate_each(record, attribute, value)
+        valid_isbn = case options[:with]
+                     when :isbn10, nil
+                       validate_with_isbn10(value)
+                     when :isbn13
+                       validate_with_isbn13(value)
+                     else 
+                       false
+                     end
 
-          configuration.update(attr_names.extract_options!)
-          validates_each(attr_names, configuration) do |record, attr_name, value|
-            valid = case configuration[:with]
-            when :isbn10
-              validate_with_isbn10(value)
-            when :isbn13
-              validate_with_isbn13(value)
-            else
-              validate_with_isbn10(value) || validate_with_isbn13(value)
-            end
-            record.errors.add(attr_name, configuration[:message]) unless valid
-          end
+        unless valid_isbn || ((value.blank? && options[:allow_nil]))
+          record.errors.add(attribute, options[:message]) 
         end
+      end
 
-        def validate_with_isbn10(isbn) #:nodoc:
-          if (isbn || '').match(ISBN10_REGEX)
-            isbn_values = isbn.upcase.gsub(/\ |-/, '').split('')
-            check_digit = isbn_values.pop # last digit is check digit
-            check_digit = (check_digit == 'X') ? 10 : check_digit.to_i
+      private
 
-            sum = 0
-            isbn_values.each_with_index do |value, index|
-              sum += (index + 1) * value.to_i
-            end
+      def validate_with_isbn10(isbn) #:nodoc:
+        if (isbn || '').match(ISBN10_REGEX)
+          isbn_values = isbn.upcase.gsub(/\ |-/, '').split('')
+          check_digit = isbn_values.pop # last digit is check digit
+          check_digit = (check_digit == 'X') ? 10 : check_digit.to_i
 
-            (sum % 11) == check_digit
-          else
-            false
+          sum = 0
+          isbn_values.each_with_index do |value, index|
+            sum += (index + 1) * value.to_i
           end
+
+          (sum % 11) == check_digit
+        else
+          false
         end
+      end
 
-        def validate_with_isbn13(isbn) #:nodoc:
-          if (isbn || '').match(ISBN13_REGEX)
-            isbn_values = isbn.upcase.gsub(/\ |-/, '').split('')
-            check_digit = isbn_values.pop.to_i # last digit is check digit
+      def validate_with_isbn13(isbn) #:nodoc:
+        if (isbn || '').match(ISBN13_REGEX)
+          isbn_values = isbn.upcase.gsub(/\ |-/, '').split('')
+          check_digit = isbn_values.pop.to_i # last digit is check digit
 
-            sum = 0
-            isbn_values.each_with_index do |value, index|
-              multiplier = (index % 2 == 0) ? 1 : 3
-              sum += multiplier * value.to_i
-            end
-
-            result = (10 - (sum % 10))
-            result = 0 if result == 10
-
-            result == check_digit
-          else
-            false
+          sum = 0
+          isbn_values.each_with_index do |value, index|
+            multiplier = (index % 2 == 0) ? 1 : 3
+            sum += multiplier * value.to_i
           end
+
+          result = (10 - (sum % 10))
+          result = 0 if result == 10
+
+          result == check_digit
+        else
+          false
         end
+      end
+    end
+
+
+    module ClassMethods
+      def validates_isbn(*attr_names)
+        validates_with IsbnFormatValidator, _merge_attributes(attr_names)
       end
     end
   end
 end
 
-ActiveRecord::Base.send(:include, Zerosum::ValidationExtensions::IsbnValidation)
+ActiveRecord::Base.send(:include, ValidationExtensions::IsbnValidation)

--- a/test/isbn_validation_test.rb
+++ b/test/isbn_validation_test.rb
@@ -2,96 +2,98 @@ require File.dirname(__FILE__) + '/test_helper'
 require File.dirname(__FILE__) + '/models'
 
 class IsbnValidationTest < Test::Unit::TestCase
-  def setup
-    @book = Book.new
-  end
-
   def test_isbn10_should_match_regex
     isbn = '1590599934'
-    assert isbn.match(Zerosum::ValidationExtensions::IsbnValidation::ISBN10_REGEX)
+    assert isbn.match(ValidationExtensions::IsbnValidation::ISBN10_REGEX)
   end
 
   def test_isbn10_should_not_match_regex
     isbn = 'abc123ab3344'
-    assert !isbn.match(Zerosum::ValidationExtensions::IsbnValidation::ISBN10_REGEX)
+    assert !isbn.match(ValidationExtensions::IsbnValidation::ISBN10_REGEX)
   end
 
   def test_isbn10_with_dashes_and_spaces_should_match_regex
     isbn = '159-059 9934'
-    assert isbn.match(Zerosum::ValidationExtensions::IsbnValidation::ISBN10_REGEX)
+    assert isbn.match(ValidationExtensions::IsbnValidation::ISBN10_REGEX)
   end
 
   def test_isbn13_should_match_regex
     isbn = '9781590599938'
-    assert isbn.match(Zerosum::ValidationExtensions::IsbnValidation::ISBN13_REGEX)
+    assert isbn.match(ValidationExtensions::IsbnValidation::ISBN13_REGEX)
   end
 
   def test_isbn13_should_not_match_regex
     isbn = '9991a9010599938'
-    assert !isbn.match(Zerosum::ValidationExtensions::IsbnValidation::ISBN13_REGEX)
+    assert !isbn.match(ValidationExtensions::IsbnValidation::ISBN13_REGEX)
   end
 
   def test_isbn13_with_dashes_and_spaces_should_match_regex
     isbn = '978-159059 9938'
-    assert isbn.match(Zerosum::ValidationExtensions::IsbnValidation::ISBN13_REGEX)
+    assert isbn.match(ValidationExtensions::IsbnValidation::ISBN13_REGEX)
   end
 
+
   def test_isbn10_should_pass_check_digit_verification
-    @book.isbn = '159059993-4'
-    assert @book.valid?
+    book = Book10.new
+    book.isbn = '159059993-4'
+    assert book.valid?
   end
 
   def test_isbn10_should_fail_check_digit_verification
-    @book.isbn = '159059993-0'
-    assert !@book.valid?
+    book = Book10.new
+    book.isbn = '159059993-0'
+    assert !book.valid?
   end
 
   def test_isbn10_should_handle_x_character_checksum
-    @book.isbn = '0-9722051-1-X'
-    assert @book.valid?
+    book = Book10.new
+    book.isbn = '0-9722051-1-X'
+    assert book.valid?
   end
 
+
   def test_isbn13_should_pass_check_digit_verification
-    @book.isbn = '978-1590599938'
-    assert @book.valid?
+    book = Book13.new
+    book.isbn = '978-1590599938'
+    assert book.valid?
   end
 
   def test_isbn13_should_fail_check_digit_verification
-    @book.isbn = '978-1590599934'
-    assert !@book.valid?
+    book = Book13.new
+    book.isbn = '978-1590599934'
+    assert !book.valid?
   end
 
-  def test_isbn_should_be_valid_if_either_isbn10_or_isbn13
-    @book.isbn = '978-1590599938'
-    assert @book.valid?
-    @book.isbn = '1590599934'
-    assert @book.valid?
+  def test_isbn13_with_zero_check_digit_should_validate
+    book = Book13.new
+    book.isbn = '978-1-60746-006-0'
+    assert book.valid?
   end
 
-  def test_isbn_should_validate_only_isbn10
-    @book = Book10.new
-    @book.isbn = '978-1590599938'
-    assert !@book.valid?
-    @book.isbn = '1590599934'
-    assert @book.valid?
-  end
 
-  def test_isbn_should_validate_only_isbn13
-    @book = Book13.new
-    @book.isbn = '1590599934'
-    assert !@book.valid?
-    @book.isbn = '978-1590599938'
-    assert @book.valid?
+  def test_isbn_should_be_valid_to_isbn10_by_default
+    book = Book.new
+    book.isbn = '1590599934'
+    assert book.valid?
   end
 
   def test_should_have_custom_error_message
-    @book.isbn = '978-159059AAAAAA'
-    @book.valid?
-    assert_equal 'is too fantastical!', @book.errors[:isbn].first
+    book = Book.new
+    book.isbn = '978-159059AAAAAA'
+    book.valid?
+    assert_equal 'is too fantastical!', book.errors[:isbn].first
   end
   
-  def test_isbn13_with_zero_check_digit_should_validate
-    @book.isbn = '978-1-60746-006-0'
-    assert @book.valid?
+  def test_blank_should_not_be_valid_by_default
+    book = Book13.new
+    book.isbn = ''
+    book.valid?
+    assert_equal 'is not a valid ISBN code', book.errors[:isbn].first
+  end
+  
+  def test_should_have_an_option_to_allow_nil
+    book = Book10.new
+    book.isbn = ''
+    assert book.valid?
   end
 end

--- a/test/models.rb
+++ b/test/models.rb
@@ -4,10 +4,10 @@ end
 
 class Book10 < ActiveRecord::Base
   set_table_name 'books'
-  validates_isbn :isbn, :with => :isbn10
+  validates_isbn :isbn, :with => :isbn10, :allow_nil => true
 end
 
 class Book13 < ActiveRecord::Base
   set_table_name 'books'
-  validates_isbn :isbn, :with => :isbn13
+  validates_isbn :isbn, :with => :isbn13, :allow_nil => false
 end


### PR DESCRIPTION
- Updated the to use the nifty EachValidator syntax. 
  The old syntax is still supported.
- Added an option to :allow_nil

Now you can use both:

```
validates :isbn, :isbn_format => true # Defaults to isbn10
validates :isbn, :isbn_format => { :with => :isbn10 }
validates :isbn, :isbn_format => { :with => :isbn13 }

# As sometimes I would like to have an isbn field I wouldn't
# want it to be mandatory.
validates :isbn, :isbn_format => { :with => :isbn10, :allow_nil => true } 
```

The gem gem also support the old syntax:

```
validates_isbn :isbn, :with => :isbn10
```

Hope that's what you meant... =]
