### PR TITLE
Added additional check to ensure ISBN 13s start with 978 or 979

### DIFF
--- a/lib/isbn_validation.rb
+++ b/lib/isbn_validation.rb
@@ -73,6 +73,7 @@ module ValidationExtensions
       def validate_with_isbn13(isbn) #:nodoc:
         if (isbn || '').match(ISBN13_REGEX)
           isbn_values = isbn.upcase.gsub(/\ |-/, '').split('')
+          return false if !isbn_values[0..2].join('').match(/(978|979)/)
           check_digit = isbn_values.pop.to_i # last digit is check digit
 
           sum = 0

--- a/test/isbn_validation_test.rb
+++ b/test/isbn_validation_test.rb
@@ -32,6 +32,16 @@ class IsbnValidationTest < ActiveSupport::TestCase
     assert isbn.match(ValidationExtensions::IsbnValidation::ISBN13_REGEX)
   end
 
+  test "isbn13 should start with 978 or 979" do
+    book = Book.new
+    book.isbn = '0123456789012'
+    assert !book.valid?
+    book.isbn = '9781590599938'
+    assert book.valid?
+    book.isbn = '979-10-90636-07-1'
+    assert book.valid?
+  end
+
   test "isbn should match either isbn10 or isbn13" do
     book = Book.new
     book.isbn = 'invalid'


### PR DESCRIPTION
Valid ISBN13s should start with 978 or 979. A random string such as `0123456789012` passes, though while that is numerically correct, it's not an ISBN. See http://www.isbn-check.de/checkisbn.pl?isbn=0123456789012&submit=test&lang=en